### PR TITLE
Fix 404 error handling

### DIFF
--- a/halfshell/source_s3.go
+++ b/halfshell/source_s3.go
@@ -56,8 +56,7 @@ func (s *S3ImageSource) GetImage(request *ImageSourceOptions) (*Image, error) {
 		return nil, err
 	}
 	if httpResponse.StatusCode != 200 {
-		s.Logger.Warnf("Error downlading image (url=%v)", httpRequest.URL)
-		return nil, err
+		return nil, fmt.Errorf("Error downlading image (url=%v)", httpRequest.URL)
 	}
 	image, err := NewImageFromBuffer(httpResponse.Body)
 	if err != nil {


### PR DESCRIPTION
Currently panics when the image is not found (`err` object it's trying to return is `nil`).
