### PR TITLE
More expressive routes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,7 @@ deps:
 format:
 	go fmt ./...
 
-.PHONY: clean format deps build
+test:
+	go test ./...
+
+.PHONY: clean format deps build test

--- a/halfshell/config.go
+++ b/halfshell/config.go
@@ -49,6 +49,9 @@ type RouteConfig struct {
 	Name            string
 	Pattern         *regexp.Regexp
 	ImagePathIndex  int
+	WidthIndex      int
+	HeightIndex     int
+	ExtensionIndex  int
 	SourceConfig    *SourceConfig
 	ProcessorConfig *ProcessorConfig
 }
@@ -130,7 +133,7 @@ func (c *configParser) parse() *Config {
 
 	routesData := c.data["routes"].(map[string]interface{})
 	for routePatternString := range routesData {
-		routeConfig := &RouteConfig{ImagePathIndex: -1}
+		routeConfig := &RouteConfig{ImagePathIndex: -1, WidthIndex: -1, HeightIndex: -1, ExtensionIndex: -1}
 		routeData := routesData[routePatternString].(map[string]interface{})
 		pattern, err := regexp.Compile(routePatternString)
 		if err != nil {
@@ -141,6 +144,15 @@ func (c *configParser) parse() *Config {
 		for i, expName := range pattern.SubexpNames() {
 			if expName == "image_path" {
 				routeConfig.ImagePathIndex = i
+			}
+			if expName == "width" {
+				routeConfig.WidthIndex = i
+			}
+			if expName == "height" {
+				routeConfig.HeightIndex = i
+			}
+			if expName == "extension" {
+				routeConfig.ExtensionIndex = i
 			}
 		}
 

--- a/halfshell/route.go
+++ b/halfshell/route.go
@@ -34,6 +34,9 @@ type Route struct {
 	Name           string
 	Pattern        *regexp.Regexp
 	ImagePathIndex int
+	WidthIndex     int
+	HeightIndex    int
+	ExtensionIndex int
 	Processor      ImageProcessor
 	Source         ImageSource
 	Statter        Statter
@@ -46,6 +49,9 @@ func NewRouteWithConfig(config *RouteConfig, statterConfig *StatterConfig) *Rout
 		Name:           config.Name,
 		Pattern:        config.Pattern,
 		ImagePathIndex: config.ImagePathIndex,
+		WidthIndex:     config.WidthIndex,
+		HeightIndex:    config.HeightIndex,
+		ExtensionIndex: config.ExtensionIndex,
 		Processor:      NewImageProcessorWithConfig(config.ProcessorConfig),
 		Source:         NewImageSourceWithConfig(config.SourceConfig),
 		Statter:        NewStatterWithConfig(config, statterConfig),
@@ -66,8 +72,19 @@ func (p *Route) SourceAndProcessorOptionsForRequest(r *http.Request) (
 	matches := p.Pattern.FindAllStringSubmatch(r.URL.Path, -1)[0]
 	path := matches[p.ImagePathIndex]
 
-	width, _ := strconv.ParseUint(r.FormValue("w"), 10, 32)
-	height, _ := strconv.ParseUint(r.FormValue("h"), 10, 32)
+	if p.ExtensionIndex > -1 {
+		path = path + matches[p.ExtensionIndex]
+	}
+
+	var width uint64
+	var height uint64
+	if p.WidthIndex > -1 {
+		width, _ = strconv.ParseUint(matches[p.WidthIndex], 10, 32)
+		height, _ = strconv.ParseUint(matches[p.HeightIndex], 10, 32)
+	} else {
+		width, _ = strconv.ParseUint(r.FormValue("w"), 10, 32)
+		height, _ = strconv.ParseUint(r.FormValue("h"), 10, 32)
+	}
 	blurRadius, _ := strconv.ParseFloat(r.FormValue("blur"), 64)
 	focalpoint := r.FormValue("focalpoint")
 

--- a/halfshell/route_test.go
+++ b/halfshell/route_test.go
@@ -1,0 +1,88 @@
+package halfshell
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestRoutes(t *testing.T) {
+
+	basicRoute := RouteForName("basic")
+
+	if basicRoute == nil {
+		t.Fatal("basicRoute should not be nil")
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com/basic/image.jpg?w=25&h=10", nil)
+
+	if !basicRoute.ShouldHandleRequest(req) {
+		t.Fail()
+	}
+
+	basicSourceOptions, basicProcessorOptions := basicRoute.SourceAndProcessorOptionsForRequest(req)
+
+	if "/image.jpg" != basicSourceOptions.Path {
+		t.Fail()
+	}
+
+	if 25 != basicProcessorOptions.Dimensions.Width {
+		t.Fail()
+	}
+
+	if 10 != basicProcessorOptions.Dimensions.Height {
+		t.Fail()
+	}
+}
+
+func TestComplexRoute(t *testing.T) {
+
+	complexRoute := RouteForName("complex")
+
+	if complexRoute == nil {
+		t.Fatal("complexRoute should not be nil")
+	}
+
+	reqForOriginalImage, _ := http.NewRequest("GET", "http://example.com/complex/image.jpg", nil)
+
+	if !complexRoute.ShouldHandleRequest(reqForOriginalImage) {
+		t.Fail()
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com/complex/image.100x50.jpg", nil)
+
+	if !complexRoute.ShouldHandleRequest(req) {
+		t.Fail()
+	}
+
+	complexSourceOptions, complexProcessorOptions := complexRoute.SourceAndProcessorOptionsForRequest(req)
+
+	if "/image.jpg" != complexSourceOptions.Path {
+		t.Fail()
+	}
+
+	if 100 != complexProcessorOptions.Dimensions.Width {
+		t.Fail()
+	}
+
+	if 50 != complexProcessorOptions.Dimensions.Height {
+		t.Fail()
+	}
+
+}
+
+func RouteForName(name string) *Route {
+	config := NewConfigFromFile("testdata/config.json")
+
+	var targetRoute *Route
+
+	for _, routeConfig := range config.RouteConfigs {
+
+		route := NewRouteWithConfig(routeConfig, config.StatterConfig)
+
+		if name == route.Name {
+			targetRoute = route
+		}
+	}
+
+	return targetRoute
+}

--- a/halfshell/route_test.go
+++ b/halfshell/route_test.go
@@ -34,27 +34,63 @@ func TestRoutes(t *testing.T) {
 	}
 }
 
-func TestComplexRoute(t *testing.T) {
+func TestRouteWithDimensionsInFilename(t *testing.T) {
 
-	complexRoute := RouteForName("complex")
+	route := RouteForName("dimensions-embedded-in-filename")
 
-	if complexRoute == nil {
-		t.Fatal("complexRoute should not be nil")
+	if route == nil {
+		t.Fatal("route should not be nil")
 	}
 
 	reqForOriginalImage, _ := http.NewRequest("GET", "http://example.com/complex/image.jpg", nil)
 
-	if !complexRoute.ShouldHandleRequest(reqForOriginalImage) {
-		t.Fail()
+	if !route.ShouldHandleRequest(reqForOriginalImage) {
+		t.Error("Route should handle request for original image")
 	}
 
 	req, _ := http.NewRequest("GET", "http://example.com/complex/image.100x50.jpg", nil)
 
-	if !complexRoute.ShouldHandleRequest(req) {
+	if !route.ShouldHandleRequest(req) {
+		t.Error("Route should handle rqeuest for resized image")
+	}
+
+	complexSourceOptions, complexProcessorOptions := route.SourceAndProcessorOptionsForRequest(req)
+
+	if "/image.jpg" != complexSourceOptions.Path {
 		t.Fail()
 	}
 
-	complexSourceOptions, complexProcessorOptions := complexRoute.SourceAndProcessorOptionsForRequest(req)
+	if 100 != complexProcessorOptions.Dimensions.Width {
+		t.Fail()
+	}
+
+	if 50 != complexProcessorOptions.Dimensions.Height {
+		t.Fail()
+	}
+
+}
+
+func TestRouteWithDimensionsInPath(t *testing.T) {
+
+	route := RouteForName("dimensions-in-path")
+
+	if route == nil {
+		t.Fatal("route should not be nil")
+	}
+
+	reqForOriginalImage, _ := http.NewRequest("GET", "http://example.com/complex/image.jpg", nil)
+
+	if !route.ShouldHandleRequest(reqForOriginalImage) {
+		t.Error("Route should handle request for original image")
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.com/complex/100x50/image.jpg", nil)
+
+	if !route.ShouldHandleRequest(req) {
+		t.Error("Route should handle rqeuest for resized image")
+	}
+
+	complexSourceOptions, complexProcessorOptions := route.SourceAndProcessorOptionsForRequest(req)
 
 	if "/image.jpg" != complexSourceOptions.Path {
 		t.Fail()

--- a/halfshell/testdata/config.json
+++ b/halfshell/testdata/config.json
@@ -30,7 +30,12 @@
             "processor": "default"
         },
         "^/complex(?P<image_path>/.*?)(\\.(?P<width>[0-9]+)x(?P<height>[0-9]+)(?P<extension>\\..*))?$": {
-            "name": "complex",
+            "name": "dimensions-embedded-in-filename",
+            "source": "default",
+            "processor": "default"
+        },
+        "^/complex(/(?P<width>[0-9]+)x(?P<height>[0-9]+))?(?P<image_path>/.*)?$": {
+            "name": "dimensions-in-path",
             "source": "default",
             "processor": "default"
         }

--- a/halfshell/testdata/config.json
+++ b/halfshell/testdata/config.json
@@ -1,0 +1,38 @@
+{
+    "server": {
+        "port": 8080,
+        "read_timeout": 5,
+        "write_timeout": 30
+    },
+    "statsd": {
+      "host": "0",
+      "port": 12345
+    },
+    "sources": {
+        "default": {
+            "type": "filesystem",
+            "directory": "testdata/images"
+        }
+    },
+    "processors": {
+        "default": {
+            "image_compression_quality": 85,
+            "default_scale_mode": "aspect_crop",
+            "max_blur_radius_percentage": 0,
+            "max_image_height": 0,
+            "max_image_width": 1000
+        }
+    },
+    "routes": {
+        "^/basic(?P<image_path>/.*)$": {
+            "name": "basic",
+            "source": "default",
+            "processor": "default"
+        },
+        "^/complex(?P<image_path>/.*?)(\\.(?P<width>[0-9]+)x(?P<height>[0-9]+)(?P<extension>\\..*))?$": {
+            "name": "complex",
+            "source": "default",
+            "processor": "default"
+        }
+    }
+}


### PR DESCRIPTION
The [announcement blog post](http://oyster.engineering/post/79458380259/resizing-images-on-the-fly-with-go) mentioned interest in extracting dimensions from the URL path, as opposed to just a query parameter. This actually fits our current thumbnail path patterns, so it would make our migration from our current thumbnailer to Halfshell much simpler. Because of the complex patterns this opens up, I added a few test cases in `route_test.go`, to guard against regressions and provide some examples.

One thing I’m not sure about is the semantics of leaking `-1` to mean “not configured” for the new pattern match indices. Being a Go newbie, I don’t know if this is a common pattern. My instinct is `-1` should be confined to the route config parsing logic, and we should use some other indicator in `SourceAndProcessorOptionsForRequest`, but I’m unsure what the convention might be.
