### PR TITLE
Add http source type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Halfshell
 
-Halfshell is a proxy server for processing images on the fly. It allows you to dynamically resize (and apply effects to) images hosted on S3 or a local filesystem via query parameters. It supports creating “families” of images which can read from distinct image sources and enable different configuration values for image processing and retrieval. See the [introduction blog post](http://engineering.oysterbooks.com/post/79458380259/resizing-images-on-the-fly-with-go).
+Halfshell is a proxy server for processing images on the fly. It allows you to dynamically resize (and apply effects to) images hosted on S3, a local filesystem or an http source via query parameters. It supports creating “families” of images which can read from distinct image sources and enable different configuration values for image processing and retrieval. See the [introduction blog post](http://engineering.oysterbooks.com/post/79458380259/resizing-images-on-the-fly-with-go).
 
 Current version: `0.1.1`
 
@@ -10,7 +10,7 @@ Halfshell was architected to be extensible from the beginning. The system is com
 
 ### Sources
 
-Sources are repositories from which an “original” image can be loaded. They return an image given a path. Currently, sources for downloading images from S3 and a local filesystem are included.
+Sources are repositories from which an “original” image can be loaded. They return an image given a path. Currently, sources for downloading images from S3, a local filesystem and http are included.
 
 ### Processors
 

--- a/examples/http_config.json
+++ b/examples/http_config.json
@@ -1,0 +1,32 @@
+{
+    "server": {
+        "port": 8081,
+        "read_timeout": 5,
+        "write_timeout": 30
+    },
+    "statsd": {
+      "enabled": false
+    },
+    "sources": {
+        "default": {
+            "type": "http",
+            "host": "myhostname.com"
+        }
+    },
+    "processors": {
+        "default": {
+            "image_compression_quality": 85,
+            "default_scale_mode": "aspect_fill",
+            "max_blur_radius_percentage": 0,
+            "max_image_height": 0,
+            "max_image_width": 1000
+        }
+    },
+    "routes": {
+        "(?P<image_path>/.*)": {
+            "name": "images",
+            "source" :"default",
+            "processor": "default"
+        }
+    }
+}

--- a/halfshell/config.go
+++ b/halfshell/config.go
@@ -62,6 +62,7 @@ type SourceConfig struct {
 	S3Bucket    string
 	S3SecretKey string
 	Directory   string
+	Host        string
 }
 
 // ProcessorConfig holds the configuration settings for the image processor.
@@ -206,6 +207,7 @@ func (c *configParser) parseSourceConfig(sourceName string) *SourceConfig {
 		S3SecretKey: c.stringForKeypath("sources.%s.s3_secret_key", sourceName),
 		S3Bucket:    c.stringForKeypath("sources.%s.s3_bucket", sourceName),
 		Directory:   c.stringForKeypath("sources.%s.directory", sourceName),
+		Host:        c.stringForKeypath("sources.%s.host", sourceName),
 	}
 }
 

--- a/halfshell/source_http.go
+++ b/halfshell/source_http.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2014 Oyster
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package halfshell
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	ImageSourceTypeHttp ImageSourceType = "http"
+)
+
+type HttpImageSource struct {
+	Config *SourceConfig
+	Logger *Logger
+}
+
+func NewHttpImageSourceWithConfig(config *SourceConfig) ImageSource {
+	return &HttpImageSource{
+		Config: config,
+		Logger: NewLogger("source.http.%s", config.Name),
+	}
+}
+
+func (s *HttpImageSource) GetImage(request *ImageSourceOptions) (*Image, error) {
+	httpRequest := s.getHttpRequest(request)
+	httpResponse, err := http.DefaultClient.Do(httpRequest)
+	defer httpResponse.Body.Close()
+	if err != nil {
+		s.Logger.Warnf("Error downlading image: %v", err)
+		return nil, err
+	}
+	if httpResponse.StatusCode != 200 {
+		return nil, fmt.Errorf("Error downlading image (url=%v)", httpRequest.URL)
+	}
+	image, err := NewImageFromBuffer(httpResponse.Body)
+	if err != nil {
+		responseBody, _ := ioutil.ReadAll(httpResponse.Body)
+		s.Logger.Warnf("Unable to create image from response body: %v (url=%v)", string(responseBody), httpRequest.URL)
+		return nil, err
+	}
+	s.Logger.Infof("Successfully retrieved image from http: %v", httpRequest.URL)
+	return image, nil
+}
+
+func (s *HttpImageSource) getHttpRequest(request *ImageSourceOptions) *http.Request {
+	path := s.Config.Directory + request.Path
+	imageURLPathComponents := strings.Split(path, "/")
+
+	for index, component := range imageURLPathComponents {
+		component = url.QueryEscape(component)
+		imageURLPathComponents[index] = component
+	}
+	requestURL := &url.URL{
+		Opaque: strings.Join(imageURLPathComponents, "/"),
+		Scheme: "http",
+		Host:   s.Config.Host,
+	}
+
+	httpRequest, _ := http.NewRequest("GET", requestURL.RequestURI(), nil)
+	httpRequest.URL = requestURL
+
+	return httpRequest
+}
+
+func init() {
+	RegisterSource(ImageSourceTypeHttp, NewHttpImageSourceWithConfig)
+}


### PR DESCRIPTION
This is a proposal to add an `http` source type to halfshell.  