### PR TITLE
Remove old Vagrant build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Contributions are welcome.
 
 ### Building
 
-There's a Nix file set up to ease development. After you have Nix installed, and have installed the halfshell package, simply run `make`.
+There's a Nix file set up to ease development. After you have Nix installed, and have installed the halfshell package, activate the nix shell, then simply run `make`.
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -282,8 +282,7 @@ Contributions are welcome.
 
 ### Building
 
-There's a Vagrant file set up to ease development. After you have the
-Vagrant box set up, cd to the /vagrant directory and run `make`.
+There's a Nix file set up to ease development. After you have Nix installed, and have installed the halfshell package, simply run `make`.
 
 ### Notes
 


### PR DESCRIPTION
Minor update to the build docs since the Vagrant file has been removed in favor of Nix.
