### PR TITLE
Fix progressive jpeg support

### DIFF
--- a/halfshell/image_processor.go
+++ b/halfshell/image_processor.go
@@ -271,7 +271,7 @@ func (ip *imageProcessor) resizeApply(img *Image, dimensions ImageDimensions) er
 	}
 
 	if img.Wand.GetImageFormat() == "JPEG" {
-		err = img.Wand.SetImageInterlaceScheme(imagick.INTERLACE_PLANE)
+		err = img.Wand.SetInterlaceScheme(imagick.INTERLACE_PLANE)
 		if err != nil {
 			ip.Logger.Errorf("Failed setting image interlace scheme: %s", err)
 			return err


### PR DESCRIPTION
Fixes progressive jpeg support by using SetInterlaceScheme instead of SetImageInterlaceScheme (which doesn't seem to do anything).