### PR TITLE
Updated readme for dockers build and fixed s3 library path (oyster/s3 does not exist)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,12 @@ Contributions are welcome.
 
 ### Building
 
-There's a Vagrant file set up to ease development. After you have the
-Vagrant box set up, cd to the /vagrant directory and run `make`.
+There's a Dockerfile set up to ease development. After you have the
+Docker set up [Docker Installation](https://docs.docker.com/engine/installation/mac/), run following from root directory of this repository,
+
+1. `docker build -f Dockerfile .` (Copy image id after build is complete)
+2. `docker run --publish 8080:8080  [IMAGE ID] config.json`
+3. Hit `localhost:8080\your_route\path_to_image.jpg`
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Docker set up [Docker Installation](https://docs.docker.com/engine/installation/
 
 1. `docker build -f Dockerfile .` (Copy image id after build is complete)
 2. `docker run --publish 8080:8080  [IMAGE ID] config.json`
-3. Hit `localhost:8080\your_route\path_to_image.jpg`
+3. Hit `[VIRTUALBOX_IP]:8080\your_route\path_to_image.jpg`
 
 ### Notes
 

--- a/halfshell/source_s3.go
+++ b/halfshell/source_s3.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/oysterbooks/s3"
+	"github.com/rafikk/s3"
 )
 
 const (


### PR DESCRIPTION
Hey guys,

I am pretty new to dockers and was stuck on how to run `halfshell` on dockers. I thought this update will helpful for others who might get stuck in similar situation.

Feel free to suggest any changes, as mentioned i am new to dockers so there might be better ways doing/writing this.
